### PR TITLE
fix: add hover tooltips to footer policy links

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -144,14 +144,26 @@ const Footer = () => {
               <a className="group relative hover:text-white transition-colors duration-300">
                 <span className="relative z-10">Privacy Policy</span>
                 <div className="absolute inset-0 bg-gradient-to-r from-primary-600/20 to-purple-600/20 rounded-lg opacity-0 group-hover:opacity-100 transition-opacity duration-300 -inset-2"></div>
+                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-3 w-64 p-3 bg-gray-900 border border-gray-700 text-gray-300 text-xs rounded-lg shadow-xl invisible group-hover:visible opacity-0 group-hover:opacity-100 transition-all duration-200 z-50 pointer-events-none">
+                  We protect your personal data and never share it with third parties without your consent. Your privacy is our priority.
+                  <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-900"></div>
+                </div>
               </a>
               <a className="group relative hover:text-white transition-colors duration-300">
                 <span className="relative z-10">Terms of Service</span>
                 <div className="absolute inset-0 bg-gradient-to-r from-primary-600/20 to-purple-600/20 rounded-lg opacity-0 group-hover:opacity-100 transition-opacity duration-300 -inset-2"></div>
+                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-3 w-64 p-3 bg-gray-900 border border-gray-700 text-gray-300 text-xs rounded-lg shadow-xl invisible group-hover:visible opacity-0 group-hover:opacity-100 transition-all duration-200 z-50 pointer-events-none">
+                  By using JobPortal, you agree to our terms. We reserve the right to modify services and are not liable for third-party content.
+                  <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-900"></div>
+                </div>
               </a>
               <a className="group relative hover:text-white transition-colors duration-300">
                 <span className="relative z-10">Cookie Policy</span>
                 <div className="absolute inset-0 bg-gradient-to-r from-primary-600/20 to-purple-600/20 rounded-lg opacity-0 group-hover:opacity-100 transition-opacity duration-300 -inset-2"></div>
+                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-3 w-64 p-3 bg-gray-900 border border-gray-700 text-gray-300 text-xs rounded-lg shadow-xl invisible group-hover:visible opacity-0 group-hover:opacity-100 transition-all duration-200 z-50 pointer-events-none">
+                  We use cookies to enhance your experience, analyze traffic, and personalize content. By using JobPortal, you consent to our cookie usage.
+                  <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-900"></div>
+                </div>
               </a>
               <Link
                 to="/contact"


### PR DESCRIPTION
Closes #2

## Summary
- Added tooltip popups to Privacy Policy, Terms of Service, and Cookie Policy links in the footer
- Tooltips appear on hover with a brief description of each policy
- Styled consistently with the footer's existing dark theme (gray-900 background, gray-700 border)
- Added a downward-pointing caret to anchor the tooltip visually

## Test plan
- [ ] Hover over "Cookie Policy" in the footer — tooltip with cookie usage text should appear above it
- [ ] Hover over "Privacy Policy" — tooltip with privacy text should appear
- [ ] Hover over "Terms of Service" — tooltip with ToS text should appear
- [ ] Verify tooltips do not interfere with other footer elements
- [ ] Check on mobile (tooltips are pointer-events-none and won't block touch targets)