### PR TITLE
fix: add hover tooltip to Contact Us link in footer

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -171,6 +171,10 @@ const Footer = () => {
               >
                 <span className="relative z-10">Contact Us</span>
                 <div className="absolute inset-0 bg-gradient-to-r from-primary-600/20 to-purple-600/20 rounded-lg opacity-0 group-hover:opacity-100 transition-opacity duration-300 -inset-2"></div>
+                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-3 w-64 p-3 bg-gray-900 border border-gray-700 text-gray-300 text-xs rounded-lg shadow-xl invisible group-hover:visible opacity-0 group-hover:opacity-100 transition-all duration-200 z-50 pointer-events-none">
+                  Have a question or facing an issue? Send a message to our admin team and we'll get back to you as soon as possible.
+                  <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-900"></div>
+                </div>
               </Link>
             </div>
             <div className="text-center md:text-right">


### PR DESCRIPTION
Adds a hover tooltip to the "Contact Us" link in the footer, consistent with the Privacy Policy, Terms of Service, and Cookie Policy links.

Closes #5

Generated with [Claude Code](https://claude.ai/code)